### PR TITLE
ci: refactor release workflow

### DIFF
--- a/.ci/cirrus-release.sh
+++ b/.ci/cirrus-release.sh
@@ -13,6 +13,50 @@ main() {
   "$subcmd" "$@"
 }
 
+changelog_section() {
+  local changelog_file="$1"
+  local tag="$2"
+  local version="${tag#v}"
+
+  need_cmd awk
+
+  awk -v version_header_pat="^## \\\[$version\\\] - " '
+    BEGIN {
+      version_section = 0
+      urls_section = 0
+    }
+
+    # Start printing when the version section is found including the section
+    # header
+    $0 ~ version_header_pat {
+      version_section = 1
+      print
+      next
+    }
+    # Stop printing when the next version section is found or when the urls
+    # section is found
+    version_section == 1 && (/^## \[/ || /^<!-- next-url -->$/) {
+      version_section = 0
+    }
+    # Print lines while in the version section
+    version_section == 1 {
+      print
+    }
+    # Start printing when the urls section is found, including the section
+    # comment
+    /^<!-- next-url -->$/ {
+      urls_section = 1
+      print
+      next
+    }
+    # Print lines while in the urls section
+    urls_section == 1 {
+      print
+    }
+  ' "$changelog_file"
+
+}
+
 ci_download() {
   local artifact="$1"
   shift
@@ -35,6 +79,40 @@ ci_download() {
     --output "$dest" \
     "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$artifact" \
     "${@:---}"
+}
+
+fix_gh_release_body_json() {
+  need_cmd awk
+
+  awk '
+    BEGIN {
+      body_nls = 0
+      body_one_line = 0
+    }
+
+    # If key with body ends with " or ", then it is a one-liner
+    /"body":.*[^\\]"$/ || /"body":.*[^\\]",$/ {
+      body_one_line = 1
+    }
+    # If key with body is not a one-liner, then there are newlines to escape
+    /"body":.*$/ && body_one_line == 0 {
+      body_nls = 1
+    }
+    # If we are escaping newlines and the end of this line ends with " or ",
+    # then escaping is done
+    body_nls == 1 && (/[^\\]"$/ || /[^\\]",$/) {
+      body_nls = 0
+    }
+
+    # Print line as normal if we are not escaping newlines
+    body_nls == 0 {
+      print
+    }
+    # If we are escaping newlines, then do that
+    body_nls == 1 {
+      printf "%s%s", $0, "\\n"
+    }
+  '
 }
 
 gh_create_release() {
@@ -81,6 +159,8 @@ gh_create_version_release() {
     prerelease=false
   fi
 
+  echo "--- Creating GitHub *draft* release '$tag' for '$repo'"
+
   gh_create_release \
     "$repo" \
     "$tag" \
@@ -88,6 +168,58 @@ gh_create_version_release() {
     "Release ${tag#v}" \
     true \
     "$prerelease"
+}
+
+gh_publish_release() {
+  local repo="$1"
+  local tag="$2"
+  local changelog_file="$3"
+
+  need_cmd jo
+  need_cmd jq
+
+  local release_id
+  release_id="$(gh_release_id_for_tag "$repo" "$tag")"
+
+  local changelog_section
+  changelog_section="$(changelog_section "$changelog_file" "$tag")"
+
+  local body
+  body="$changelog_section"
+
+  local payload
+  payload="$(
+    jo \
+      draft=false \
+      name="Release ${tag#v}" \
+      body="$body"
+  )"
+
+  echo "--- Publishing GitHub release '$tag' for '$repo'"
+
+  local response
+  if ! response="$(
+    gh_rest POST "/repos/$repo/releases/$release_id" --data "$payload"
+  )"; then
+    echo "!!! Failed to update a release for tag $tag" >&2
+    return 1
+  fi
+}
+
+gh_release_id_for_tag() {
+  local repo="$1"
+  local tag="$2"
+
+  need_cmd jq
+  need_cmd sed
+
+  local response
+  if ! response="$(gh_rest GET "/repos/$repo/releases/tags/$tag")"; then
+    echo "!!! Failed to find a release for tag $tag" >&2
+    return 1
+  fi
+
+  echo "$response" | fix_gh_release_body_json | jq -r .id
 }
 
 gh_release_upload_url_for_tag() {

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -272,9 +272,8 @@ ci_success_task:
   clone_script: mkdir -p "$CIRRUS_WORKING_DIR"
   success_script: /bin/true
 
-release_artifacts_task:
-  name: release-artifacts-${BIN}
-  alias: release-artifacts
+create_github_release_task:
+  name: create-github-release
   only_if: $CIRRUS_TAG != ''
   depends_on:
     - build-bins
@@ -306,7 +305,7 @@ release_artifacts_task:
     done
     cp "$manifest" .
     ls -l "$BIN"*
-  upload_release_artifacts_script: |
+  upload_github_release_artifacts_script: |
     url="$(cat /tmp/upload_url)"
     ./.ci/cirrus-release.sh gh_upload_all "$url" /tmp/release
 
@@ -314,32 +313,41 @@ build_docker_image_docker_builder:
   name: build-docker-image-${BIN}
   alias: build-docker-images
   only_if: $CIRRUS_TAG != ''
-  depends_on:
-    - release-artifacts-fnichol-cime
   env:
     AUTHOR: Fletcher Nichol <fnichol@nichol.ca>
     LICENSE: MPL-2.0
     BIN: fnichol-cime
-    REPO: fnichol/${BIN}
-    IMG: ${REPO}
+    REPO: fnichol/$BIN
+    IMG: $REPO
+    TARGET: x86_64-unknown-linux-musl
+    EXT: tar.gz
+    ARCHIVE: $BIN-$TARGET.$EXT
     DOCKER_USERNAME: ENCRYPTED[3e38482137ca39fa18416c90a31e9567c6cde8506b30ddba7d083a3799a3d7e55a919976a74b50f47274e0b69233c507]
     DOCKER_PASSWORD: ENCRYPTED[5df55aa8c424d33286f8bfecdb710231fa00809ce41dc517bead679f863ec84c6a8147b93ea9e8888513f01d8f8351a7]
+  download_cirrus_artifacts_script: |
+    cr="$(readlink -f ./.ci/cirrus-release.sh)"
+    mkdir -p /tmp/artifacts
+    cd /tmp/artifacts
+    "$cr" ci_download "build-bin-$ARCHIVE/binaries/$ARCHIVE"
+    "$cr" ci_download "build-bin-$ARCHIVE/binaries/$ARCHIVE.sha256"
   build_script: |
     ./.ci/build-docker-image.sh \
-      "$IMG" "$REPO" "$AUTHOR" "$LICENSE" "$BIN" "${CIRRUS_TAG#v}"
+      "$IMG" "${CIRRUS_TAG#v}" "$REPO" "$AUTHOR" "$LICENSE" "$BIN" \
+      "/tmp/artifacts/$ARCHIVE"
   login_script: |
     echo "$DOCKER_PASSWORD" \
       | docker login --username "$DOCKER_USERNAME" --password-stdin
-  push_script:
-    - docker push "$IMG:${CIRRUS_TAG#v}"
-    - docker push "$IMG:latest"
+  push_script: |
+    docker push "$IMG:${CIRRUS_TAG#v}"
+    docker push "$IMG:latest"
 
-publish_create_task:
+publish_crate_task:
   name: publish-crate-${CRATE}
   alias: publish-crates
   only_if: $CIRRUS_TAG =~ 'v.*'
   depends_on:
-    - release-artifacts-fnichol-cime
+    - create-github-release
+    - build-docker-images
   env:
     CRATE: fnichol-cime
     CRATES_IO_TOKEN: ENCRYPTED[0c6ba7d0bd264cf02d59451d0135eb215d2774a9eb86e89dd9bfb3cab6a1c4aaa48a69edfb3d0ae6f4850441e6e591bb]
@@ -349,13 +357,30 @@ publish_create_task:
   login_script: echo "$CRATES_IO_TOKEN" | cargo login
   publish_script: cargo publish
 
+publish_github_release_task:
+  name: publish-github-release
+  only_if: $CIRRUS_TAG != ''
+  depends_on:
+    - create-github-release
+    - build-docker-images
+    - publish-crates
+  container:
+    image: alpine:3
+  env:
+    GITHUB_TOKEN: ENCRYPTED[ecc4ca0e5df9225981292126d56d588b2c2ccbc2fd73ad4fc92696cf6ef2613f03b7776b2b1c4fd3586381c0a796f041]
+  install_dependencies_script: apk add curl jo jq
+  publish_release_script: |
+    ./.ci/cirrus-release.sh gh_publish_release \
+      "$CIRRUS_REPO_FULL_NAME" "$CIRRUS_TAG" CHANGELOG.md
+
 release_success_task:
   name: release-success
   only_if: $CIRRUS_TAG != ''
   depends_on:
-    - release-artifacts
+    - create-github-release
     - build-docker-images
     - publish-crates
+    - publish-github-release
   container:
     image: alpine:3
   clone_script: mkdir -p "$CIRRUS_WORKING_DIR"


### PR DESCRIPTION
This change rolls up several release workflow updates:

* Fix the Docker image build program to use the Cirrus CI build artifact
  rather than the GitHub release asset (as the release is still in draft
  and therefore not publicly visible). The program no longer downloads
  directly, but rather is provided a path to the archive to operate
  upon.
* Add a `publish-github-release` task which fires after any crates are
  published. This task takes the corresponding section from the
  CHANGELOG to populate the body of the GitHub release.
* The Docker build task no longer has to wait on the creation of a draft
  GitHub release so it can work in parallel.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>